### PR TITLE
feat(): Add VoskProvider for offline STT and comprehensive unit tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,10 @@ dependencies {
 
     // Vosk — offline speech recognition with a Java API
     // Models are downloaded on first use (~50 MB for the small English model)
-    implementation("com.alphacephei:vosk:0.3.45")
+    // JNA is excluded because IntelliJ Platform already bundles it
+    implementation("com.alphacephei:vosk:0.3.32") {
+        exclude(group = "net.java.dev.jna", module = "jna")
+    }
 
     implementation("com.github.axet:TarsosDSP:2.4-1")
 
@@ -52,10 +55,16 @@ kotlin {
     jvmToolchain(21)
 }
 
+val voskNativeDir = "${rootDir}/libs"
+
 tasks.test {
     useJUnitPlatform()
+    jvmArgs("-Djna.library.path=$voskNativeDir")
 }
 
+tasks.named<JavaExec>("runIde") {
+    jvmArgs("-Djna.library.path=$voskNativeDir")
+}
 
 intellijPlatform {
     instrumentCode = false

--- a/src/main/kotlin/com/danilian/speakide/stt/SttProviderFactory.kt
+++ b/src/main/kotlin/com/danilian/speakide/stt/SttProviderFactory.kt
@@ -10,7 +10,7 @@ object SttProviderFactory {
     fun create(settings: SpeakIdeSettings = SpeakIdeSettings.getInstance()): SttProvider {
         return when (settings.state.sttProvider) {
             SttProviderOption.VOSK.id -> VoskProvider(settings.state.voskModelPath)
-            else -> OpenAiWhisperProvider()   // default: OpenAI Whisper
+            else -> OpenAiWhisperProvider.create(settings)
         }
     }
 }

--- a/src/main/kotlin/com/danilian/speakide/stt/vosk/VoskProvider.kt
+++ b/src/main/kotlin/com/danilian/speakide/stt/vosk/VoskProvider.kt
@@ -1,0 +1,88 @@
+package com.danilian.speakide.stt.vosk
+
+import com.danilian.speakide.stt.SttProvider
+import com.danilian.speakide.stt.SttResult
+import com.intellij.openapi.Disposable
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import org.vosk.Model
+import org.vosk.Recognizer
+import java.io.File
+import java.io.FileNotFoundException
+
+class VoskProvider(private val modelPath: String) : SttProvider, Disposable {
+
+    companion object {
+        private const val SAMPLE_RATE = 44100f
+        private val TEXT_PATTERN = Regex(""""text"\s*:\s*"([^"]*)"""")
+
+        fun parseVoskResult(json: String): SttResult {
+            val text = TEXT_PATTERN.find(json)
+                ?.groupValues
+                ?.getOrNull(1)
+                ?.trim()
+                .orEmpty()
+            return SttResult(text = text)
+        }
+    }
+
+    override val displayName = "Vosk (Offline)"
+    override val requiresNetwork = false
+
+    private var model: Model? = null
+    private val mutex = Mutex()
+    private var disposed = false
+
+    private suspend fun getOrLoadModel(): Model {
+        model?.let { return it }
+
+        return mutex.withLock {
+            model?.let { return@withLock it }
+
+            if (disposed) error("VoskProvider is already disposed")
+
+            val path = modelPath.ifBlank {
+                throw IllegalArgumentException(
+                    "Vosk model path is not set. " +
+                    "Set it in Settings → Tools → SpeakIDE → Vosk Model Path."
+                )
+            }
+
+            val dir = File(path)
+            if (!dir.exists() || !dir.isDirectory) {
+                throw FileNotFoundException("Vosk model not found at: $path")
+            }
+
+            println("=== VoskProvider: loading model from $path ===")
+            val loaded = withContext(Dispatchers.IO) { Model(path) }
+            println("=== VoskProvider: model loaded ===")
+            model = loaded
+            loaded
+        }
+    }
+
+    override suspend fun transcribe(audioData: ByteArray, language: String?): SttResult {
+        if (audioData.isEmpty()) return SttResult(text = "")
+
+        val m = getOrLoadModel()
+
+        println("=== VoskProvider: transcribing ${audioData.size} bytes ===")
+        val resultJson = withContext(Dispatchers.IO) {
+            Recognizer(m, SAMPLE_RATE).use { recognizer ->
+                recognizer.acceptWaveForm(audioData, audioData.size)
+                recognizer.finalResult
+            }
+        }
+        println("=== VoskProvider: raw result = $resultJson ===")
+
+        return parseVoskResult(resultJson)
+    }
+
+    override fun dispose() {
+        disposed = true
+        model?.close()
+        model = null
+    }
+}

--- a/src/test/kotlin/com/danilian/speakide/stt/vosk/VoskProviderTest.kt
+++ b/src/test/kotlin/com/danilian/speakide/stt/vosk/VoskProviderTest.kt
@@ -1,0 +1,77 @@
+package com.danilian.speakide.stt.vosk
+
+import io.mockk.unmockkConstructor
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.vosk.Model
+import org.vosk.Recognizer
+import java.io.FileNotFoundException
+
+class VoskProviderTest {
+
+    @AfterEach
+    fun tearDown() {
+        // Clean up constructor mocks after each test.
+        unmockkConstructor(Model::class)
+        unmockkConstructor(Recognizer::class)
+    }
+
+    @Test
+    fun `parseVoskResult extracts text from valid json`() {
+        val result = VoskProvider.parseVoskResult("""{"text": "hello world"}""")
+        assertEquals("hello world", result.text)
+    }
+
+    @Test
+    fun `parseVoskResult returns empty string for empty json`() {
+        val result = VoskProvider.parseVoskResult("""{"text": ""}""")
+        assertEquals("", result.text)
+    }
+
+    @Test
+    fun `parseVoskResult trims whitespace`() {
+        val result = VoskProvider.parseVoskResult("""{"text" : "  hello  "}""")
+        assertEquals("hello", result.text)
+    }
+
+    @Test
+    fun `parseVoskResult returns empty string for malformed json`() {
+        val result = VoskProvider.parseVoskResult("not json at all")
+        assertEquals("", result.text)
+    }
+
+    @Test
+    fun `transcribe returns empty result for empty audio`() = runBlocking {
+        val provider = VoskProvider("")
+        val result = provider.transcribe(ByteArray(0), null)
+        assertEquals("", result.text)
+    }
+
+    @Test
+    fun `transcribe throws IllegalArgumentException when modelPath is blank`() {
+        val provider = VoskProvider("")
+        assertThrows<IllegalArgumentException> {
+            runBlocking { provider.transcribe(ByteArray(100), null) }
+        }
+    }
+
+    @Test
+    fun `transcribe throws FileNotFoundException when model directory does not exist`() {
+        val provider = VoskProvider("/nonexistent/path/to/model")
+        assertThrows<FileNotFoundException> {
+            runBlocking { provider.transcribe(ByteArray(100), null) }
+        }
+    }
+
+    @Test
+    fun `transcribe throws after dispose`() {
+        val provider = VoskProvider("/some/path")
+        provider.dispose()
+        assertThrows<IllegalStateException> {
+            runBlocking { provider.transcribe(ByteArray(100), null) }
+        }
+    }
+}


### PR DESCRIPTION
- Implement `VoskProvider` for offline speech-to-text processing with Vosk API.
- Add parsing utility for Vosk JSON results.
- Introduce detailed unit tests for `VoskProvider` functionality and error handling.
- Update Gradle build to include Vosk dependency with JNA exclusion.
- Configure native library path for Vosk in `test` and `runIde` tasks.