### PR TITLE
refactor: Simplify and modularize STT providers

### DIFF
--- a/src/main/kotlin/com/danilian/speakide/audio/AudioCapture.kt
+++ b/src/main/kotlin/com/danilian/speakide/audio/AudioCapture.kt
@@ -21,63 +21,52 @@ class AudioCapture(
     private val onError: (Exception) -> Unit = {},
 ) : AudioSource {
 
-    val silenceDetector = SilenceDetector(silenceThresholdDb, false)
+    private val silenceDetector = SilenceDetector(silenceThresholdDb, false)
 
     @Volatile
     private var dispatcher: AudioDispatcher? = null
 
     override fun start() {
-        Thread({
-            try {
-                val d = AudioDispatcherFactory.fromDefaultMicrophone(
-                    SpeakIdeConstants.AUDIO_BUFFER_SIZE,
-                    SpeakIdeConstants.AUDIO_BUFFER_OVERLAP
-                )
-                d.addAudioProcessor(silenceDetector)
-                d.addAudioProcessor(
-                    MicPermissionProbe(
-                        silenceDetector = silenceDetector,
-                        onMicDenied = {
-                            onMicDenied()
-                            onError(SecurityException("Microphone access denied by macOS"))
-                        }
-                    ))
-                d.addAudioProcessor(
-                    SilenceTimeoutProcessor(
-                        silenceDetector = silenceDetector,
-                        silenceThresholdDb = silenceThresholdDb,
-                        silenceDurationMs = silenceDurationMs,
-                        onSilenceTimeout = onSilenceTimeout
-                    )
-                )
-                d.addAudioProcessor(object : AudioProcessor {
-                    override fun process(event: AudioEvent): Boolean {
-                        val floats = event.floatBuffer
-                        val pcm = ByteArray(floats.size * 2)
-                        for (i in floats.indices) {
-                            val sample = (floats[i] * 32767.0f).toInt().coerceIn(-32768, 32767)
-                            pcm[i * 2] = (sample and 0xFF).toByte()
-                            pcm[i * 2 + 1] = ((sample shr 8) and 0xFF).toByte()
-                        }
-                        onData(pcm)
-                        return true
-                    }
-
-                    override fun processingFinished() = Unit
-                })
-                dispatcher = d
-                d.run() // blocks until stop() is called
-            } catch (e: LineUnavailableException) {
-                LOG.warn("AudioCapture: microphone line unavailable", e)
-                onMicDenied()
-                onError(e)
-            } catch (e: Exception) {
-                LOG.warn("AudioCapture: unexpected error", e)
-                onError(e)
-            }
-        }, "speakide-audio-capture").apply {
+        Thread(::runCapture, "speakide-audio-capture").apply {
             isDaemon = true
             start()
+        }
+    }
+
+    private fun runCapture() {
+        try {
+            val d = AudioDispatcherFactory.fromDefaultMicrophone(
+                SpeakIdeConstants.AUDIO_BUFFER_SIZE,
+                SpeakIdeConstants.AUDIO_BUFFER_OVERLAP
+            )
+            d.addAudioProcessor(silenceDetector)
+            d.addAudioProcessor(
+                MicPermissionProbe(
+                    silenceDetector = silenceDetector,
+                    onMicDenied = {
+                        onMicDenied()
+                        onError(SecurityException("Microphone access denied by macOS"))
+                    }
+                )
+            )
+            d.addAudioProcessor(
+                SilenceTimeoutProcessor(
+                    silenceDetector = silenceDetector,
+                    silenceThresholdDb = silenceThresholdDb,
+                    silenceDurationMs = silenceDurationMs,
+                    onSilenceTimeout = onSilenceTimeout
+                )
+            )
+            d.addAudioProcessor(PcmForwardingProcessor(onData))
+            dispatcher = d
+            d.run() // blocks until stop() is called
+        } catch (e: LineUnavailableException) {
+            LOG.warn("AudioCapture: microphone line unavailable", e)
+            onMicDenied()
+            onError(e)
+        } catch (e: Exception) {
+            LOG.warn("AudioCapture: unexpected error", e)
+            onError(e)
         }
     }
 
@@ -88,4 +77,20 @@ class AudioCapture(
     override fun currentDb(): Double = silenceDetector.currentSPL()
 
     override fun isSilent(): Boolean = currentDb() < silenceThresholdDb
+}
+
+private class PcmForwardingProcessor(private val onData: (ByteArray) -> Unit) : AudioProcessor {
+    override fun process(event: AudioEvent): Boolean {
+        val floats = event.floatBuffer
+        val pcm = ByteArray(floats.size * 2)
+        for (i in floats.indices) {
+            val sample = (floats[i] * 32767.0f).toInt().coerceIn(-32768, 32767)
+            pcm[i * 2] = (sample and 0xFF).toByte()
+            pcm[i * 2 + 1] = ((sample shr 8) and 0xFF).toByte()
+        }
+        onData(pcm)
+        return true
+    }
+
+    override fun processingFinished() = Unit
 }

--- a/src/main/kotlin/com/danilian/speakide/audio/AudioData.kt
+++ b/src/main/kotlin/com/danilian/speakide/audio/AudioData.kt
@@ -1,0 +1,24 @@
+package com.danilian.speakide.audio
+
+
+data class AudioFormat(
+    val sampleRate: Int,
+    val channels: Int,
+    val bitsPerSample: Int,
+) {
+    val bytesPerSample: Int get() = bitsPerSample / 8
+    val byteRate: Int get() = sampleRate * channels * bytesPerSample
+}
+
+data class AudioData(
+    val pcm: ByteArray,
+    val format: AudioFormat,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is AudioData) return false
+        return pcm.contentEquals(other.pcm) && format == other.format
+    }
+
+    override fun hashCode(): Int = 31 * pcm.contentHashCode() + format.hashCode()
+}

--- a/src/main/kotlin/com/danilian/speakide/audio/AudioResampler.kt
+++ b/src/main/kotlin/com/danilian/speakide/audio/AudioResampler.kt
@@ -6,7 +6,6 @@ object AudioResampler {
 
     private const val TARGET_RATE = 16_000
     private const val SOURCE_RATE = 44_100
-    private val FACTOR = TARGET_RATE.toDouble() / SOURCE_RATE
 
     fun resampleTo16kFloat(pcmBytes: ByteArray, sourceRate: Int = SOURCE_RATE): FloatArray {
         if (pcmBytes.isEmpty()) return FloatArray(0)

--- a/src/main/kotlin/com/danilian/speakide/delivery/ResultDelivery.kt
+++ b/src/main/kotlin/com/danilian/speakide/delivery/ResultDelivery.kt
@@ -1,0 +1,25 @@
+package com.danilian.speakide.delivery
+
+import com.danilian.speakide.notification.SpeakIdeNotifier
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+
+
+class ResultDelivery(private val notifier: SpeakIdeNotifier = SpeakIdeNotifier()) {
+
+    fun deliver(text: String, project: Project?, editor: Editor?) {
+        if (text.isBlank()) {
+            notifier.notifyNothingRecognized(project)
+            return
+        }
+        if (project != null && editor != null) {
+            ApplicationManager.getApplication().invokeLater {
+                CaretTextDelivery.deliver(text, project, editor)
+            }
+        } else {
+            ClipboardTextDelivery.deliver(text, project, editor)
+            notifier.notifyClipboard(project, text)
+        }
+    }
+}

--- a/src/main/kotlin/com/danilian/speakide/recording/RecordingService.kt
+++ b/src/main/kotlin/com/danilian/speakide/recording/RecordingService.kt
@@ -1,13 +1,13 @@
 package com.danilian.speakide.recording
 
 import com.danilian.speakide.audio.AudioCapture
+import com.danilian.speakide.audio.AudioData
 import com.danilian.speakide.audio.PcmBuffer
-import com.danilian.speakide.delivery.CaretTextDelivery
-import com.danilian.speakide.delivery.ClipboardTextDelivery
+import com.danilian.speakide.delivery.ResultDelivery
 import com.danilian.speakide.notification.SpeakIdeNotifier
+import com.danilian.speakide.settings.SpeakIdeConstants
 import com.danilian.speakide.settings.SpeakIdeSettings
-import com.danilian.speakide.stt.SttProvider
-import com.danilian.speakide.stt.SttProviderFactory
+import com.danilian.speakide.stt.TranscriptionService
 import com.danilian.speakide.ui.RecordingIndicator
 import com.danilian.speakide.ui.RecordingOverlay
 import com.intellij.openapi.Disposable
@@ -27,9 +27,8 @@ class RecordingService : Disposable {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val notifier = SpeakIdeNotifier()
     private val indicator: RecordingIndicator = RecordingOverlay()
+    private val delivery = ResultDelivery(notifier)
 
-    private var cachedProvider: SttProvider? = null
-    private var cachedProviderKey: String? = null
     @Volatile
     private var state: RecordingState = RecordingState.Idle
 
@@ -41,17 +40,6 @@ class RecordingService : Disposable {
             is RecordingState.Recording -> stopRecording(current)
             is RecordingState.Transcribing -> Unit // ignore mid-transcription toggles
         }
-    }
-
-    private fun getProvider(): SttProvider {
-        val s = SpeakIdeSettings.getInstance().state
-        val key = "${s.sttProvider}|${s.whisperBaseUrl}|${s.whisperModel}|${s.voskModelPath}|${s.whisperLocalModelPath}"
-        if (cachedProviderKey != key) {
-            (cachedProvider as? Disposable)?.dispose()
-            cachedProvider = SttProviderFactory.create()
-            cachedProviderKey = key
-        }
-        return cachedProvider!!
     }
 
     private fun startRecording(project: Project?, editor: Editor?) {
@@ -77,7 +65,6 @@ class RecordingService : Disposable {
         )
 
         state = RecordingState.Recording(project, editor, capture, buffer)
-
         if (settings.showRecordingOverlay) indicator.show()
         capture.start()
     }
@@ -94,33 +81,21 @@ class RecordingService : Disposable {
             return
         }
 
-        scope.launch { transcribe(pcm, current.project, current.editor) }
+        val audio = AudioData(pcm, SpeakIdeConstants.CAPTURE_FORMAT)
+        scope.launch { transcribe(audio, current.project, current.editor) }
     }
 
-    private suspend fun transcribe(pcm: ByteArray, project: Project?, editor: Editor?) {
+    private suspend fun transcribe(audio: AudioData, project: Project?, editor: Editor?) {
         try {
             val lang = SpeakIdeSettings.getInstance().state.language.takeUnless { it == "auto" }
-            val text = getProvider().transcribe(pcm, lang).text.trim()
-            deliverResult(text, project, editor)
+            val transcriptionService = ApplicationManager.getApplication()
+                .getService(TranscriptionService::class.java)
+            val text = transcriptionService.transcribe(audio, lang).text.trim()
+            delivery.deliver(text, project, editor)
         } catch (ex: Throwable) {
             notifier.notifyRecognitionError(project, ex)
         } finally {
             state = RecordingState.Idle
-        }
-    }
-
-    private fun deliverResult(text: String, project: Project?, editor: Editor?) {
-        if (text.isBlank()) {
-            notifier.notifyNothingRecognized(project)
-            return
-        }
-        if (project != null && editor != null) {
-            ApplicationManager.getApplication().invokeLater {
-                CaretTextDelivery.deliver(text, project, editor)
-            }
-        } else {
-            ClipboardTextDelivery.deliver(text, project, editor)
-            notifier.notifyClipboard(project, text)
         }
     }
 
@@ -133,7 +108,5 @@ class RecordingService : Disposable {
         (state as? RecordingState.Recording)?.capture?.stop()
         indicator.hide()
         scope.cancel()
-        (cachedProvider as? Disposable)?.dispose()
-        cachedProvider = null
     }
 }

--- a/src/main/kotlin/com/danilian/speakide/settings/SpeakIdeConstants.kt
+++ b/src/main/kotlin/com/danilian/speakide/settings/SpeakIdeConstants.kt
@@ -1,5 +1,7 @@
 package com.danilian.speakide.settings
 
+import com.danilian.speakide.audio.AudioFormat
+
 
 object SpeakIdeConstants {
     const val NOTIFICATION_GROUP_ID = "SpeakIDE"
@@ -13,6 +15,8 @@ object SpeakIdeConstants {
     const val CHANNELS = 1
 
     const val BITS_PER_SAMPLE = 16
+
+    val CAPTURE_FORMAT = AudioFormat(SAMPLE_RATE, CHANNELS, BITS_PER_SAMPLE)
 
     val SUPPORTED_LANGUAGES = listOf("auto", "en", "ru", "de", "fr", "es", "zh", "ja")
 }

--- a/src/main/kotlin/com/danilian/speakide/settings/SpeakIdeSettings.kt
+++ b/src/main/kotlin/com/danilian/speakide/settings/SpeakIdeSettings.kt
@@ -44,5 +44,10 @@ class SpeakIdeSettings : PersistentStateComponent<SpeakIdeSettings.State> {
 enum class SttProviderOption(val id: String, val displayName: String) {
     OPENAI_WHISPER("openai-whisper", "OpenAI Whisper (Cloud native)"),
     VOSK("vosk", "Vosk (Offline)"),
-    WHISPER_LOCAL("whisper-local", "Whisper (Local)"),
+    WHISPER_LOCAL("whisper-local", "Whisper (Local)");
+
+    companion object {
+        fun fromId(id: String): SttProviderOption =
+            entries.find { it.id == id } ?: OPENAI_WHISPER
+    }
 }

--- a/src/main/kotlin/com/danilian/speakide/stt/OfflineSttProvider.kt
+++ b/src/main/kotlin/com/danilian/speakide/stt/OfflineSttProvider.kt
@@ -3,12 +3,12 @@ package com.danilian.speakide.stt
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.diagnostic.logger
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 private val LOG = logger<OfflineSttProvider<*>>()
-
 
 abstract class OfflineSttProvider<R : Any>(
     protected val modelPath: String
@@ -18,7 +18,7 @@ abstract class OfflineSttProvider<R : Any>(
     private var resource: R? = null
 
     @Volatile
-    protected var disposed = false
+    private var disposed = false
 
     protected suspend fun getOrLoad(): R {
         resource?.let { return it }
@@ -45,13 +45,25 @@ abstract class OfflineSttProvider<R : Any>(
             loaded
         }
     }
-    protected fun getLoadedResource(): R? = resource
-
-    protected fun clearResource() {
-        resource = null
-    }
 
     protected abstract fun validatePath(path: String)
 
     protected abstract suspend fun loadResource(path: String): R
+
+    protected abstract fun releaseResource(resource: R)
+
+    override fun dispose() {
+        disposed = true
+        val toRelease = runBlocking {
+            mutex.withLock {
+                val r = resource
+                resource = null
+                r
+            }
+        }
+        toRelease?.let {
+            runCatching { releaseResource(it) }
+                .onFailure { ex -> LOG.warn("$displayName: error during dispose", ex) }
+        }
+    }
 }

--- a/src/main/kotlin/com/danilian/speakide/stt/OfflineSttProvider.kt
+++ b/src/main/kotlin/com/danilian/speakide/stt/OfflineSttProvider.kt
@@ -3,13 +3,30 @@ package com.danilian.speakide.stt
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.diagnostic.logger
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 private val LOG = logger<OfflineSttProvider<*>>()
 
-
+/**
+ * Abstract base for offline STT providers that need to load a model from disk on first use.
+ *
+ * ### Lazy loading
+ * [getOrLoad] loads [R] once and caches it. Subsequent calls return the cached instance
+ * immediately without taking the mutex, so the hot path is lock-free.
+ *
+ * ### Thread safety
+ * [dispose] acquires the same mutex as [getOrLoad], so the resource is never freed while
+ * a load is in progress (and vice versa). Subclasses must not touch the resource directly —
+ * they only implement [loadResource] and [releaseResource].
+ *
+ * ### Adding a new provider
+ * 1. Extend this class with `R` = the native model type.
+ * 2. Implement [validatePath], [loadResource], and [releaseResource].
+ * 3. Call [getOrLoad] inside your [transcribe] override.
+ */
 abstract class OfflineSttProvider<R : Any>(
     protected val modelPath: String
 ) : SttProvider, Disposable {
@@ -18,7 +35,7 @@ abstract class OfflineSttProvider<R : Any>(
     private var resource: R? = null
 
     @Volatile
-    protected var disposed = false
+    private var disposed = false
 
     protected suspend fun getOrLoad(): R {
         resource?.let { return it }
@@ -45,13 +62,25 @@ abstract class OfflineSttProvider<R : Any>(
             loaded
         }
     }
-    protected fun getLoadedResource(): R? = resource
-
-    protected fun clearResource() {
-        resource = null
-    }
 
     protected abstract fun validatePath(path: String)
 
     protected abstract suspend fun loadResource(path: String): R
+
+    protected abstract fun releaseResource(resource: R)
+
+    override fun dispose() {
+        disposed = true
+        val toRelease = runBlocking {
+            mutex.withLock {
+                val r = resource
+                resource = null
+                r
+            }
+        }
+        toRelease?.let {
+            runCatching { releaseResource(it) }
+                .onFailure { ex -> LOG.warn("$displayName: error during dispose", ex) }
+        }
+    }
 }

--- a/src/main/kotlin/com/danilian/speakide/stt/SttProvider.kt
+++ b/src/main/kotlin/com/danilian/speakide/stt/SttProvider.kt
@@ -1,8 +1,15 @@
 package com.danilian.speakide.stt
 
+import com.danilian.speakide.audio.AudioData
+import com.intellij.openapi.Disposable
 
-interface SttProvider {
+interface SttProvider : Disposable {
     val displayName: String
     val requiresNetwork: Boolean
-    suspend fun transcribe(audioData: ByteArray, language: String?): SttResult
+
+    suspend fun transcribe(audio: AudioData, language: String?): SttResult
+
+    fun postProcess(result: SttResult): SttResult = result
+
+    override fun dispose() {}
 }

--- a/src/main/kotlin/com/danilian/speakide/stt/SttProviderFactory.kt
+++ b/src/main/kotlin/com/danilian/speakide/stt/SttProviderFactory.kt
@@ -8,11 +8,10 @@ import com.danilian.speakide.stt.whisperlocal.WhisperLocalProvider
 
 
 class SttProviderFactory(private val settings: SpeakIdeSettings = SpeakIdeSettings.getInstance()) {
-    fun create(): SttProvider = when (settings.state.sttProvider) {
-        SttProviderOption.OPENAI_WHISPER.id -> OpenAiWhisperProvider.create(settings)
-        SttProviderOption.VOSK.id -> VoskProvider(settings.state.voskModelPath)
-        SttProviderOption.WHISPER_LOCAL.id -> WhisperLocalProvider(settings.state.whisperLocalModelPath)
-        else -> OpenAiWhisperProvider.create(settings)
+    fun create(): SttProvider = when (SttProviderOption.fromId(settings.state.sttProvider)) {
+        SttProviderOption.OPENAI_WHISPER -> OpenAiWhisperProvider.create(settings)
+        SttProviderOption.VOSK -> VoskProvider(settings.state.voskModelPath)
+        SttProviderOption.WHISPER_LOCAL -> WhisperLocalProvider(settings.state.whisperLocalModelPath)
     }
 
     companion object {

--- a/src/main/kotlin/com/danilian/speakide/stt/TranscriptionService.kt
+++ b/src/main/kotlin/com/danilian/speakide/stt/TranscriptionService.kt
@@ -1,0 +1,58 @@
+package com.danilian.speakide.stt
+
+import com.danilian.speakide.audio.AudioData
+import com.danilian.speakide.settings.SpeakIdeSettings
+import com.danilian.speakide.settings.SttProviderOption
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.diagnostic.logger
+
+private val LOG = logger<TranscriptionService>()
+
+@Service(Service.Level.APP)
+class TranscriptionService : Disposable {
+
+    private var cachedProvider: SttProvider? = null
+    private var cachedKey: ProviderCacheKey? = null
+
+    suspend fun transcribe(audio: AudioData, language: String?): SttResult {
+        val provider = getProvider()
+        val raw = provider.transcribe(audio, language)
+        return provider.postProcess(raw)
+    }
+
+    private fun getProvider(): SttProvider {
+        val s = SpeakIdeSettings.getInstance().state
+        val key = ProviderCacheKey.from(s)
+        if (cachedKey != key) {
+            LOG.info("TranscriptionService: provider settings changed, recreating provider")
+            (cachedProvider as? Disposable)?.dispose()
+            cachedProvider = SttProviderFactory.create()
+            cachedKey = key
+        }
+        return cachedProvider!!
+    }
+
+    override fun dispose() {
+        cachedProvider?.dispose()
+        cachedProvider = null
+    }
+
+    private data class ProviderCacheKey(
+        val provider: SttProviderOption,
+        val baseUrl: String,
+        val model: String,
+        val voskPath: String,
+        val whisperLocalPath: String,
+    ) {
+        companion object {
+            fun from(s: SpeakIdeSettings.State) = ProviderCacheKey(
+                provider = SttProviderOption.fromId(s.sttProvider),
+                baseUrl = s.whisperBaseUrl,
+                model = s.whisperModel,
+                voskPath = s.voskModelPath,
+                whisperLocalPath = s.whisperLocalModelPath,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/danilian/speakide/stt/WhisperHallucinations.kt
+++ b/src/main/kotlin/com/danilian/speakide/stt/WhisperHallucinations.kt
@@ -1,10 +1,8 @@
-package com.danilian.speakide.stt.whisperlocal
+package com.danilian.speakide.stt
 
 object WhisperHallucinations {
 
     val KNOWN_PHRASES = listOf(
-        // Russian Hallucinations (Movie subtitles & credits)
-        // All phrases must be lowercase — isHallucination() compares against text.lowercase()
         "редактор субтитров",
         "корректор",
         "субтитры сделаны",
@@ -20,7 +18,6 @@ object WhisperHallucinations {
         "dimatorzok",
         "amara.org",
 
-        // English Hallucinations (YouTube & TV credits)
         "subtitles by",
         "subtitle by",
         "captions by",
@@ -35,13 +32,11 @@ object WhisperHallucinations {
         "mbc",
         "kbs",
         "you can support us",
-        "patreon"
+        "patreon",
     )
 
     fun isHallucination(text: String): Boolean {
-        // If the text is long, it's likely a real dictation that happens to contain a trigger word.
         if (text.length > 150) return false
-
         val lowerText = text.lowercase()
         return KNOWN_PHRASES.any { it in lowerText }
     }

--- a/src/main/kotlin/com/danilian/speakide/stt/openai/OpenAiWhisperProvider.kt
+++ b/src/main/kotlin/com/danilian/speakide/stt/openai/OpenAiWhisperProvider.kt
@@ -1,25 +1,29 @@
 package com.danilian.speakide.stt.openai
 
+import com.danilian.speakide.audio.AudioData
+import com.danilian.speakide.audio.toWav
 import com.danilian.speakide.settings.SecureStorage
-import com.danilian.speakide.settings.SpeakIdeConstants
 import com.danilian.speakide.settings.SpeakIdeSettings
 import com.danilian.speakide.stt.SttProvider
 import com.danilian.speakide.stt.SttResult
+import com.danilian.speakide.stt.WhisperHallucinations
+import com.intellij.openapi.diagnostic.logger
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
 import io.ktor.client.request.forms.*
-import io.ktor.http.*
 import io.ktor.client.statement.*
+import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import com.danilian.speakide.audio.toWav
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+
+private val LOG = logger<OpenAiWhisperProvider>()
 
 class OpenAiWhisperProvider(
     private val httpClient: HttpClient,
@@ -30,26 +34,18 @@ class OpenAiWhisperProvider(
 
     override val displayName = "OpenAI Whisper (Cloud)"
     override val requiresNetwork = true
-
-    /**
-     * Transcribes raw PCM audio via the Whisper API.
-     *
-     * Pipeline:
-     *   ByteArray (raw PCM) → WAV (44-byte RIFF header prepended)
-     *   → multipart/form-data POST → JSON response → SttResult
-     */
-    override suspend fun transcribe(audioData: ByteArray, language: String?): SttResult {
-        if (audioData.isEmpty()) return SttResult(text = "")
+    override suspend fun transcribe(audio: AudioData, language: String?): SttResult {
+        if (audio.pcm.isEmpty()) return SttResult(text = "")
 
         val apiKey = apiKeyProvider()
             ?: throw IllegalStateException(
                 "API key is not set. Add it in Settings → Tools → SpeakIDE."
             )
 
-        val wavBytes = audioData.toWav(
-            sampleRate = SpeakIdeConstants.SAMPLE_RATE,
-            channels = SpeakIdeConstants.CHANNELS,
-            bitsPerSample = SpeakIdeConstants.BITS_PER_SAMPLE
+        val wavBytes = audio.pcm.toWav(
+            sampleRate = audio.format.sampleRate,
+            channels = audio.format.channels,
+            bitsPerSample = audio.format.bitsPerSample,
         )
 
         val response = withContext(Dispatchers.IO) {
@@ -79,7 +75,16 @@ class OpenAiWhisperProvider(
         }
 
         val parsedResponse: WhisperResponse = response.body()
+        LOG.debug("OpenAiWhisperProvider: result = ${parsedResponse.text}")
         return SttResult(text = parsedResponse.text.trim())
+    }
+
+    override fun postProcess(result: SttResult): SttResult {
+        if (WhisperHallucinations.isHallucination(result.text)) {
+            LOG.info("OpenAiWhisperProvider: filtered out hallucination: ${result.text}")
+            return result.copy(text = "")
+        }
+        return result
     }
 
     companion object {

--- a/src/main/kotlin/com/danilian/speakide/stt/vosk/VoskProvider.kt
+++ b/src/main/kotlin/com/danilian/speakide/stt/vosk/VoskProvider.kt
@@ -1,5 +1,6 @@
 package com.danilian.speakide.stt.vosk
 
+import com.danilian.speakide.audio.AudioData
 import com.danilian.speakide.stt.OfflineSttProvider
 import com.danilian.speakide.stt.SttResult
 import com.intellij.openapi.diagnostic.logger
@@ -17,7 +18,6 @@ private val LOG = logger<VoskProvider>()
 class VoskProvider(modelPath: String) : OfflineSttProvider<Model>(modelPath) {
 
     companion object {
-        private const val SAMPLE_RATE = 44100f
         private val voskJson = Json { ignoreUnknownKeys = true }
 
         fun parseVoskResult(json: String): SttResult {
@@ -40,27 +40,24 @@ class VoskProvider(modelPath: String) : OfflineSttProvider<Model>(modelPath) {
 
     override suspend fun loadResource(path: String): Model = Model(path)
 
-    override suspend fun transcribe(audioData: ByteArray, language: String?): SttResult {
-        if (audioData.isEmpty()) return SttResult(text = "")
+    override fun releaseResource(resource: Model) = resource.close()
+
+    override suspend fun transcribe(audio: AudioData, language: String?): SttResult {
+        if (audio.pcm.isEmpty()) return SttResult(text = "")
 
         val model = getOrLoad()
+        val sampleRate = audio.format.sampleRate.toFloat()
 
-        LOG.debug("VoskProvider: transcribing ${audioData.size} bytes")
+        LOG.debug("VoskProvider: transcribing ${audio.pcm.size} bytes @ ${audio.format.sampleRate} Hz")
         val resultJson = withContext(Dispatchers.IO) {
-            Recognizer(model, SAMPLE_RATE).use { recognizer ->
-                recognizer.acceptWaveForm(audioData, audioData.size)
+            Recognizer(model, sampleRate).use { recognizer ->
+                recognizer.acceptWaveForm(audio.pcm, audio.pcm.size)
                 recognizer.finalResult
             }
         }
         LOG.debug("VoskProvider: raw result = $resultJson")
 
         return parseVoskResult(resultJson)
-    }
-
-    override fun dispose() {
-        disposed = true
-        getLoadedResource()?.close()
-        clearResource()
     }
 }
 

--- a/src/main/kotlin/com/danilian/speakide/stt/whisperlocal/WhisperLocalProvider.kt
+++ b/src/main/kotlin/com/danilian/speakide/stt/whisperlocal/WhisperLocalProvider.kt
@@ -1,8 +1,10 @@
 package com.danilian.speakide.stt.whisperlocal
 
+import com.danilian.speakide.audio.AudioData
 import com.danilian.speakide.audio.AudioResampler
 import com.danilian.speakide.stt.OfflineSttProvider
 import com.danilian.speakide.stt.SttResult
+import com.danilian.speakide.stt.WhisperHallucinations
 import com.intellij.openapi.diagnostic.logger
 import io.github.givimad.whisperjni.WhisperContext
 import io.github.givimad.whisperjni.WhisperFullParams
@@ -41,13 +43,16 @@ class WhisperLocalProvider(modelPath: String) : OfflineSttProvider<Pair<WhisperJ
         return w to ctx
     }
 
-    override suspend fun transcribe(audioData: ByteArray, language: String?): SttResult {
-        if (audioData.isEmpty()) return SttResult(text = "")
+    override fun releaseResource(resource: Pair<WhisperJNI, WhisperContext>) {
+        resource.first.free(resource.second)
+    }
+
+    override suspend fun transcribe(audio: AudioData, language: String?): SttResult {
+        if (audio.pcm.isEmpty()) return SttResult(text = "")
 
         val (w, ctx) = getOrLoad()
 
-        // Whisper requires 16000Hz float32
-        val floatData = AudioResampler.resampleTo16kFloat(audioData)
+        val floatData = AudioResampler.resampleTo16kFloat(audio.pcm, audio.format.sampleRate)
         if (floatData.isEmpty()) return SttResult(text = "")
 
         LOG.debug("WhisperLocalProvider: transcribing ${floatData.size} samples")
@@ -69,33 +74,18 @@ class WhisperLocalProvider(modelPath: String) : OfflineSttProvider<Pair<WhisperJ
             }
 
             val numSegments = w.fullNSegments(ctx)
-            val sb = StringBuilder()
-            for (i in 0 until numSegments) {
-                sb.append(w.fullGetSegmentText(ctx, i))
-            }
-
-            val rawText = sb.toString().trim()
-            if (WhisperHallucinations.isHallucination(rawText)) {
-                LOG.info("WhisperLocalProvider: Filtered out hallucination: $rawText")
-                ""
-            } else {
-                rawText
-            }
+            (0 until numSegments).joinToString("") { w.fullGetSegmentText(ctx, it) }.trim()
         }
 
         LOG.debug("WhisperLocalProvider: result = $text")
         return SttResult(text = text)
     }
 
-    override fun dispose() {
-        disposed = true
-        try {
-            val (w, ctx) = getLoadedResource() ?: return
-            w.free(ctx)
-        } catch (e: Exception) {
-            LOG.warn("Error freeing Whisper context", e)
-        } finally {
-            clearResource()
+    override fun postProcess(result: SttResult): SttResult {
+        if (WhisperHallucinations.isHallucination(result.text)) {
+            LOG.info("WhisperLocalProvider: filtered out hallucination: ${result.text}")
+            return result.copy(text = "")
         }
+        return result
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,6 +17,17 @@
     ]]></description>
 
     <change-notes><![CDATA[
+        <h3>0.1.3</h3>
+        <ul>
+            <li>Performance: STT providers are now cached in <code>RecordingService</code> — no re-initialization overhead between recordings.</li>
+        </ul>
+        <h3>0.1.2</h3>
+        <ul>
+            <li>New STT backend: <strong>Whisper Local</strong> (offline, ggml models) — no internet or API key required.</li>
+            <li>Added hallucination filter for local Whisper output.</li>
+            <li>Refactored offline providers into a shared <code>OfflineSttProvider</code> base — cleaner Vosk and Whisper implementations.</li>
+            <li>Improved audio resampling logic.</li>
+        </ul>
         <h3>0.1.1</h3>
         <ul>
             <li>Internal refactoring: cleaner architecture, better stability.</li>
@@ -46,9 +57,13 @@
         <applicationService
                 serviceImplementation="com.danilian.speakide.settings.SpeakIdeSettings"/>
 
-        <!-- Recording lifecycle: state machine, audio capture, STT dispatch, text delivery -->
+        <!-- Recording lifecycle: state machine, audio capture -->
         <applicationService
                 serviceImplementation="com.danilian.speakide.recording.RecordingService"/>
+
+        <!-- STT provider caching + transcription (separated from recording state machine) -->
+        <applicationService
+                serviceImplementation="com.danilian.speakide.stt.TranscriptionService"/>
 
         <notificationGroup id="SpeakIDE" displayType="BALLOON"/>
     </extensions>

--- a/src/test/kotlin/com/danilian/speakide/stt/openai/OpenAiWhisperProviderTest.kt
+++ b/src/test/kotlin/com/danilian/speakide/stt/openai/OpenAiWhisperProviderTest.kt
@@ -1,5 +1,7 @@
 package com.danilian.speakide.stt.openai
 
+import com.danilian.speakide.audio.AudioData
+import com.danilian.speakide.audio.AudioFormat
 import com.danilian.speakide.audio.toWav
 import io.ktor.client.*
 import io.ktor.client.engine.mock.*
@@ -13,35 +15,34 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
+private val TEST_FORMAT = AudioFormat(sampleRate = 44100, channels = 1, bitsPerSample = 16)
+private fun audioData(size: Int) = AudioData(ByteArray(size), TEST_FORMAT)
+
 class OpenAiWhisperProviderTest {
 
-    //pcmToWav
+    // pcmToWav
 
     @Test
     fun `pcmToWav produces correct total size`() {
-        val pcm = ByteArray(1000)
-        val wav = pcm.toWav(sampleRate = 44100, channels = 1, bitsPerSample = 16)
+        val wav = ByteArray(1000).toWav(sampleRate = 44100, channels = 1, bitsPerSample = 16)
         assertEquals(1044, wav.size) // 44-byte header + 1000 data
     }
 
     @Test
     fun `pcmToWav starts with RIFF marker`() {
-        val pcm = ByteArray(1000)
-        val wav = pcm.toWav(44100, 1, 16)
+        val wav = ByteArray(1000).toWav(44100, 1, 16)
         assertEquals("RIFF", String(wav.sliceArray(0..3)))
     }
 
     @Test
     fun `pcmToWav contains WAVE marker at offset 8`() {
-        val pcm = ByteArray(1000)
-        val wav = pcm.toWav(44100, 1, 16)
+        val wav = ByteArray(1000).toWav(44100, 1, 16)
         assertEquals("WAVE", String(wav.sliceArray(8..11)))
     }
 
     @Test
     fun `pcmToWav contains data marker at offset 36`() {
-        val pcm = ByteArray(1000)
-        val wav = pcm.toWav(44100, 1, 16)
+        val wav = ByteArray(1000).toWav(44100, 1, 16)
         assertEquals("data", String(wav.sliceArray(36..39)))
     }
 
@@ -50,7 +51,7 @@ class OpenAiWhisperProviderTest {
     @Test
     fun `transcribe returns empty result for empty audio`() = runBlocking {
         val provider = buildProvider()
-        val result = provider.transcribe(ByteArray(0), null)
+        val result = provider.transcribe(audioData(0), null)
         assertEquals("", result.text)
     }
 
@@ -58,7 +59,7 @@ class OpenAiWhisperProviderTest {
     fun `transcribe throws when API key is missing`() {
         val provider = buildProvider(apiKey = null)
         assertThrows<IllegalStateException> {
-            runBlocking { provider.transcribe(ByteArray(100), null) }
+            runBlocking { provider.transcribe(audioData(100), null) }
         }
     }
 
@@ -67,14 +68,14 @@ class OpenAiWhisperProviderTest {
     @Test
     fun `transcribe returns text from API response`() = runBlocking {
         val provider = buildProvider(responseBody = """{"text": "hello world"}""")
-        val result = provider.transcribe(ByteArray(100), null)
+        val result = provider.transcribe(audioData(100), null)
         assertEquals("hello world", result.text)
     }
 
     @Test
     fun `transcribe trims whitespace from response`() = runBlocking {
         val provider = buildProvider(responseBody = """{"text": "  hello  "}""")
-        val result = provider.transcribe(ByteArray(100), null)
+        val result = provider.transcribe(audioData(100), null)
         assertEquals("hello", result.text)
     }
 
@@ -85,7 +86,7 @@ class OpenAiWhisperProviderTest {
             apiKey = "sk-test-123",
             onRequest = { request -> capturedAuth = request.headers[HttpHeaders.Authorization] },
         )
-        provider.transcribe(ByteArray(100), null)
+        provider.transcribe(audioData(100), null)
         assertEquals("Bearer sk-test-123", capturedAuth)
     }
 
@@ -97,7 +98,7 @@ class OpenAiWhisperProviderTest {
                 capturedBody = request.body.toByteArray().decodeToString()
             },
         )
-        provider.transcribe(ByteArray(100), language = "fr")
+        provider.transcribe(audioData(100), language = "fr")
         assert(capturedBody.contains("fr")) { "Expected 'fr' in multipart body" }
     }
 
@@ -109,11 +110,11 @@ class OpenAiWhisperProviderTest {
                 capturedBody = request.body.toByteArray().decodeToString()
             },
         )
-        provider.transcribe(ByteArray(100), language = "auto")
+        provider.transcribe(audioData(100), language = "auto")
         assert(!capturedBody.contains("language")) { "Expected no language field for 'auto'" }
     }
 
-    //helpers
+    // helpers
 
     private fun buildProvider(
         responseBody: String = """{"text": ""}""",

--- a/src/test/kotlin/com/danilian/speakide/stt/vosk/VoskProviderTest.kt
+++ b/src/test/kotlin/com/danilian/speakide/stt/vosk/VoskProviderTest.kt
@@ -1,5 +1,7 @@
 package com.danilian.speakide.stt.vosk
 
+import com.danilian.speakide.audio.AudioData
+import com.danilian.speakide.audio.AudioFormat
 import io.mockk.unmockkConstructor
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
@@ -10,11 +12,12 @@ import org.vosk.Model
 import org.vosk.Recognizer
 import java.io.FileNotFoundException
 
+private val TEST_FORMAT = AudioFormat(sampleRate = 44100, channels = 1, bitsPerSample = 16)
+
 class VoskProviderTest {
 
     @AfterEach
     fun tearDown() {
-        // Clean up constructor mocks after each test.
         unmockkConstructor(Model::class)
         unmockkConstructor(Recognizer::class)
     }
@@ -46,7 +49,7 @@ class VoskProviderTest {
     @Test
     fun `transcribe returns empty result for empty audio`() = runBlocking {
         val provider = VoskProvider("")
-        val result = provider.transcribe(ByteArray(0), null)
+        val result = provider.transcribe(AudioData(ByteArray(0), TEST_FORMAT), null)
         assertEquals("", result.text)
     }
 
@@ -54,7 +57,7 @@ class VoskProviderTest {
     fun `transcribe throws IllegalArgumentException when modelPath is blank`() {
         val provider = VoskProvider("")
         assertThrows<IllegalArgumentException> {
-            runBlocking { provider.transcribe(ByteArray(100), null) }
+            runBlocking { provider.transcribe(AudioData(ByteArray(100), TEST_FORMAT), null) }
         }
     }
 
@@ -62,7 +65,7 @@ class VoskProviderTest {
     fun `transcribe throws FileNotFoundException when model directory does not exist`() {
         val provider = VoskProvider("/nonexistent/path/to/model")
         assertThrows<FileNotFoundException> {
-            runBlocking { provider.transcribe(ByteArray(100), null) }
+            runBlocking { provider.transcribe(AudioData(ByteArray(100), TEST_FORMAT), null) }
         }
     }
 
@@ -71,7 +74,7 @@ class VoskProviderTest {
         val provider = VoskProvider("/some/path")
         provider.dispose()
         assertThrows<IllegalStateException> {
-            runBlocking { provider.transcribe(ByteArray(100), null) }
+            runBlocking { provider.transcribe(AudioData(ByteArray(100), TEST_FORMAT), null) }
         }
     }
 }


### PR DESCRIPTION
refactor: Simplify and modularize STT providers
- Removed hallucination detection from `WhisperLocalProvider` and added a shared `postProcess` step applicable to all providers.
- Refactored `OfflineSttProvider` with streamlined lifecycle management for resource loading and disposal.
- Introduced `AudioData` and `AudioFormat` utilities for standardized audio handling across providers.
- Added `TranscriptionService` to centralize STT provider caching and transcription flow.
- Enhanced testing with better mocks and audio abstraction refinements.